### PR TITLE
Don't send player-leaderboards request when there is no chart hash

### DIFF
--- a/BGAnimations/ScreenGameplay underlay/PerPlayer/StepStatistics/Scorebox.lua
+++ b/BGAnimations/ScreenGameplay underlay/PerPlayer/StepStatistics/Scorebox.lua
@@ -229,7 +229,7 @@ local af = Def.ActorFrame{
 				maxLeaderboardResults=NumEntries,
 			}
 
-			if SL[pn].ApiKey ~= "" then
+			if SL[pn].ApiKey ~= "" and SL[pn].Streams.Hash ~= "" then
 				query["chartHashP"..n] = SL[pn].Streams.Hash
 				headers["x-api-key-player-"..n] = SL[pn].ApiKey
 				sendRequest = true


### PR DESCRIPTION
Sending the request without hash causes an error response from the GS
API resulting in the integration getting disabled.

fixes https://github.com/Simply-Love/Simply-Love-SM5/issues/407