### PR TITLE
Aesthetics fixes for mods

### DIFF
--- a/BGAnimations/ScreenGameplay underlay/PerPlayer/LifeMeter/Standard.lua
+++ b/BGAnimations/ScreenGameplay underlay/PerPlayer/LifeMeter/Standard.lua
@@ -21,7 +21,7 @@ end
 local meter = Def.ActorFrame{
 
 	InitCommand=function(self) self:y(20):SetUpdateFunction(Update):visible(false) end,
-	OnCommand=function(self) self:visible(true) end,
+	OnCommand=function(self) self:finishtweening():visible(true) end,
 
 	-- frame
 	Def.Quad{ InitCommand=function(self) self:x(_x):zoomto(w+4, h+4) end },

--- a/BGAnimations/ScreenGameplay underlay/PerPlayer/LifeMeter/Vertical.lua
+++ b/BGAnimations/ScreenGameplay underlay/PerPlayer/LifeMeter/Vertical.lua
@@ -140,7 +140,7 @@ local meter = Def.ActorFrame{
 	Def.Quad{
 		Name="MeterFill",
 		InitCommand=function(self) self:zoomto(width,0):diffuse(PlayerColor(player,true)):align(0,1) end,
-		OnCommand=function(self) self:xy( _x - width/2, height/2) end,
+		OnCommand=function(self) self:finishtweening():xy( _x - width/2, height/2) end,
 		
 		-- check whether the player's LifeMeter is "Hot"
 		-- in LifeMeterBar.cpp, the engine says a LifeMeter is Hot if the current

--- a/BGAnimations/ScreenGameplay underlay/PerPlayer/RunTimer.lua
+++ b/BGAnimations/ScreenGameplay underlay/PerPlayer/RunTimer.lua
@@ -1,4 +1,4 @@
-local player, layout = ...
+local player, ssY, layout = ...
 local pn = ToEnumShortString(player)
 local mods = SL[pn].ActiveModifiers
 local so = GAMESTATE:GetSongOptionsObject("ModsLevel_Song")
@@ -222,7 +222,7 @@ end
 
 local af = Def.ActorFrame{
 	InitCommand=function(self)
-		self:xy(GetNotefieldX(player), layout.y-60)
+		self:xy(GetNotefieldX(player), ssY)
 		self:queuecommand("SetUpdate")
 	end,
 	SetUpdateCommand=function(self) self:SetUpdateFunction( Update ) end,

--- a/BGAnimations/ScreenGameplay underlay/default.lua
+++ b/BGAnimations/ScreenGameplay underlay/default.lua
@@ -60,7 +60,7 @@ for player in ivalues(Players) do
 	t[#t+1] = LoadActor("./PerPlayer/TargetScore/default.lua", player)
 	t[#t+1] = LoadActor("./PerPlayer/SubtractiveScoring.lua", player, layout.SubtractiveScoring)
 	t[#t+1] = LoadActor("./PerPlayer/ColumnCues.lua", player)
-	t[#t+1] = LoadActor("./PerPlayer/RunTimer.lua", player, layout.MeasureCounter)
+	t[#t+1] = LoadActor("./PerPlayer/RunTimer.lua", player, layout.SubtractiveScoring.y, layout.MeasureCounter)
 	t[#t+1] = LoadActor("./PerPlayer/BrokenRunCounter.lua", player, layout.MeasureCounter)
 end
 

--- a/Scripts/SL-Layout.lua
+++ b/Scripts/SL-Layout.lua
@@ -48,17 +48,15 @@ function GetGameplayLayout(player, reverse)
         end
     end
 
-    if mods.MiniIndicator ~= "None" then
-        if mods.MeasureCounter ~= "None" and mods.MeasureCounterUp and mods.HideLookahead then
-            layout.SubtractiveScoring = { y = layout.MeasureCounter.y }
-        elseif mods.MeasureCounter ~= "None" and  mods.MeasureCounterUp then
-            layout.SubtractiveScoring = { y = bottomY + 8}
-            bottomY = bottomY + 16
-        else
-            layout.SubtractiveScoring = { y = topY - 8 }
-            topY = topY - 16
-        end
-    end
+	if mods.MeasureCounter ~= "None" and mods.MeasureCounterUp and mods.HideLookahead then
+		layout.SubtractiveScoring = { y = layout.MeasureCounter.y }
+	elseif mods.MeasureCounter ~= "None" and  mods.MeasureCounterUp then
+		layout.SubtractiveScoring = { y = bottomY + 8}
+		bottomY = bottomY + 16
+	else
+		layout.SubtractiveScoring = { y = topY - 8 }
+		topY = topY - 16
+	end
 
     -- Move the combo counter out of the way if it overlaps with any gameplay
     -- element.


### PR DESCRIPTION
- Fix run timer positioning to match the Y position of mini indicator (subtractive scoring)
- Fix strange graphical behavior of life bars when using quick restart