### PR TITLE
Clean GSub

### DIFF
--- a/Scripts/SL-PlayerOptions.lua
+++ b/Scripts/SL-PlayerOptions.lua
@@ -492,7 +492,7 @@ local Overrides = {
 			local GIFdir = THEME:GetCurrentThemeDirectory() .. "BGAnimations/ScreenGameplay underlay/PerPlayer/StepStatistics/GIFs/"
 			local GIFs = findFiles(GIFdir, "lua")
 			for i=1, #GIFs do
-				GIFname = GIFs[i]:gsub("/" .. THEME:GetCurrentThemeDirectory() .. "BGAnimations/ScreenGameplay underlay/PerPlayer/StepStatistics/GIFs/", ""):gsub(".lua", "")
+				GIFname = cleanGSub(cleanGSub(GIFs[i], "/" .. GIFdir, ""), ".lua", "")
 				table.insert(choices, GIFname)
 			end
 			

--- a/Scripts/Z-NewFunctions.lua
+++ b/Scripts/Z-NewFunctions.lua
@@ -13,6 +13,12 @@ findFiles=function(dir,ext)
     return files
 end
 
+cleanGSub=function(str, what, with)
+	what = what:gsub("[%(%)%.%+%-%*%?%[%]%^%$%%]", "%%%1") -- escape pattern
+	with = with:gsub("[%%]", "%%%%") -- escape replacement
+	return str:gsub(what, with)
+end
+
 -- Returns current song and steps for player
 -- Moving out of Step Statistics StepsInfo.lua
 GetSongAndSteps = function(player) 


### PR DESCRIPTION
Add cleanGSub function, to do string replacement ignoring special characters and patterns. Mostly for use on things like directory paths.