### PR TITLE
Scale timing scatterplot to worst window with steps

### DIFF
--- a/BGAnimations/ScreenEvaluation common/PerPlayer/Lower/ScatterPlot.lua
+++ b/BGAnimations/ScreenEvaluation common/PerPlayer/Lower/ScatterPlot.lua
@@ -27,14 +27,14 @@ local Offset, CurrentSecond, TimingWindow, x, y, c, r, g, b
 -- ---------------------------------------------
 -- if players have disabled W4 or W4+W5, there will be a smaller pool
 -- of judgments that could have possibly been earned
-local worst_window = GetTimingWindow(NumJudgmentsAvailable())
-local windows = SL[pn].ActiveModifiers.TimingWindows
-for i=NumJudgmentsAvailable(),1,-1 do
-	if windows[i] then
-		worst_window = GetTimingWindow(i)
-		break
-	end
-end
+local worst_window = GetTimingWindow(SL[pn].Stages.Stats[SL.Global.Stages.PlayedThisGame + 1].worst_window)
+-- local windows = SL[pn].ActiveModifiers.TimingWindows
+-- for i=NumJudgmentsAvailable(),1,-1 do
+-- 	if windows[i] then
+--		worst_window = GetTimingWindow(i)
+--		break
+--	end
+-- end
 
 -- ---------------------------------------------
 

--- a/BGAnimations/ScreenGameplay overlay/JudgmentOffsetTracking.lua
+++ b/BGAnimations/ScreenGameplay overlay/JudgmentOffsetTracking.lua
@@ -10,6 +10,7 @@ if SL.Global.GameMode == "Casual" then return end
 
 local player = ...
 local sequential_offsets = {}
+local worst_window = 1
 
 return Def.Actor{
 	JudgmentMessageCommand=function(self, params)
@@ -20,6 +21,12 @@ return Def.Actor{
 			-- If the judgment was a Miss, store the string "Miss" as offset instead of the number 0.
 			-- For all other judgments, store the offset value provided by the engine as a number.
 			local offset = params.TapNoteScore == "TapNoteScore_Miss" and "Miss" or params.TapNoteOffset
+			if offset ~= "Miss" then
+				local window = DetermineTimingWindow(offset)
+				if window > worst_window then
+					worst_window = window
+				end
+			end
 
 			-- Store judgment offsets (including misses) in an indexed table as they occur.
 			-- Also store the CurMusicSeconds for Evaluation's scatter plot.
@@ -29,5 +36,6 @@ return Def.Actor{
 	OffCommand=function(self)
 		local storage = SL[ToEnumShortString(player)].Stages.Stats[SL.Global.Stages.PlayedThisGame + 1]
 		storage.sequential_offsets = sequential_offsets
+		storage.worst_window = worst_window
 	end
 }


### PR DESCRIPTION
Store and use worst timing window that has at least one step, instead of using the worst timing window that's enabled.