### PR TITLE
Add Notefield Shift Option

### DIFF
--- a/BGAnimations/ScreenGameplay overlay/MoveNotefield.lua
+++ b/BGAnimations/ScreenGameplay overlay/MoveNotefield.lua
@@ -1,0 +1,10 @@
+-- This file moves the notefield according to player options.
+
+local player = ...
+local pn = ToEnumShortString(player)
+
+return Def.Actor{
+	OnCommand=function(self)
+		SCREENMAN:GetTopScreen():GetChild("Player"..pn):GetChild("NoteField"):addy(SL[pn].ActiveModifiers.NotefieldShift)
+	end,
+}

--- a/BGAnimations/ScreenGameplay overlay/default.lua
+++ b/BGAnimations/ScreenGameplay overlay/default.lua
@@ -40,6 +40,7 @@ for player in ivalues( GAMESTATE:GetHumanPlayers() ) do
 	af[#af+1] = LoadActor("./JudgmentOffsetTracking.lua", player)
 	af[#af+1] = LoadActor("./TrackExScoreJudgments.lua", player)
 	af[#af+1] = LoadActor("./TrackFailTime.lua", player)
+	af[#af+1] = LoadActor("./MoveNotefield.lua", player)
 
 	-- FIXME: refactor PerColumnJudgmentTracking to not be inside this loop
 	--        the Lua input callback logic shouldn't be duplicated for each player

--- a/BGAnimations/ScreenGameplay underlay/PerPlayer/ColumnCues.lua
+++ b/BGAnimations/ScreenGameplay underlay/PerPlayer/ColumnCues.lua
@@ -106,7 +106,7 @@ for columnIndex=1,numColumns do
 					:accelerate(fadeTime)
 					:diffuse(0,0,0,0)
 				
-				if flashDuration >= 5 then
+				if flashDuration >= 5 and mods.ColumnCountdown then
 					breakTime = flashDuration
 					text:stoptweening()
 						:x((columnIndex - (numColumns/2 + 0.5)) * (width/numColumns))
@@ -126,7 +126,7 @@ for columnIndex=1,numColumns do
 					:diffuse(0,0,0,0)
 					:horizalign(center)
 					:x((columnIndex - (numColumns/2 + 0.5)) * (width/numColumns))
-					:y(80)
+					:y(80+mods.NotefieldShift)
 				text = self
 			end,
 			UpdateBreakCommand=function(self)

--- a/Languages/en.ini
+++ b/Languages/en.ini
@@ -682,6 +682,7 @@ MeasureCounterOptions=Measure Counter\nOptions
 MeasureCounter=Measure Counter
 LifeMeterType=LifeMeter Type
 VisualDelay=Visual Delay
+NotefieldShift=Notefield Shift
 ScreenAfterPlayerOptions2=What comes next?
 
 # ScreenPlayerOptions3
@@ -897,6 +898,7 @@ TimingWindows=Disable certain Timing Windows at your discretion.
 ScreenAfterPlayerOptions2=Go back and choose a different song or change additional modifiers.
 LifeMeterType="Surround" positions the LifeMeter vertically behind the\nplayfield. "Vertical" positions it vertically beside the playfield.
 VisualDelay=Player specific visual delay. Negative values shifts the arrows upwards, while positive values move them down.
+NotefieldShift=Shifts the entire notefield including targets up or down. Negative values shifts the arrows upwards, while positive values move them down.
 
 # ScreenPlayerOptions3
 ScreenAfterPlayerOptions3=Go back and choose a different song or change additional modifiers.
@@ -1054,6 +1056,7 @@ TrackEarlyJudgments=Track Early Judgments
 NPSGraphAtTop=Density Graph at Top
 JudgmentTilt=Judgment Tilt
 ColumnCues=Column Cues
+ColumnCountdown=Column Countdown
 DisplayScorebox=Display Scorebox
 
 # ErrorBar

--- a/Scripts/SL-PlayerOptions.lua
+++ b/Scripts/SL-PlayerOptions.lua
@@ -555,13 +555,13 @@ local Overrides = {
 		Values = function()
 			local vals = {}
 			if IsUsingWideScreen() then
-				vals = { "JudgmentTilt", "ColumnCues" }
+				vals = { "JudgmentTilt", "ColumnCues", "ColumnCountdown" }
 				if IsServiceAllowed(SL.GrooveStats.GetScores) then
 					vals[#vals+1] = "DisplayScorebox"
 				end
 			else
 				-- Add in the two removed options if not in WideScreen.
-				vals = { "MissBecauseHeld", "NPSGraphAtTop", "JudgmentTilt", "ColumnCues" }
+				vals = { "MissBecauseHeld", "NPSGraphAtTop", "JudgmentTilt", "ColumnCues", "ColumnCountdown" }
 			end
 			return vals
 		end
@@ -643,6 +643,26 @@ local Overrides = {
 				end
 			end
 			playeroptions:VisualDelay( mods.VisualDelay:gsub("ms","")/1000 )
+		end
+	},
+	-------------------------------------------------------------------------
+	NotefieldShift = {
+		Choices = function()
+			local first = -100
+			local last = 100
+			local step = 1
+			return stringify( range(first, last, step), "%g")
+		end,
+		ExportOnChange = true,
+		LayoutType = "ShowOneInRow",
+		SaveSelections = function(self, list, pn)
+			local mods, playeroptions = GetModsAndPlayerOptions(pn)
+
+			for i=1,#self.Choices do
+				if list[i] then
+					mods.NotefieldShift = self.Choices[i]
+				end
+			end
 		end
 	},
 	-------------------------------------------------------------------------

--- a/Scripts/SL-PlayerProfiles.lua
+++ b/Scripts/SL-PlayerProfiles.lua
@@ -74,6 +74,7 @@ local permitted_profile_settings = {
 	SmallerWhite     = "boolean",
 
 	VisualDelay          = "string",
+	NotefieldShift       = "string",
 	
 	FlashMiss            = "boolean",
 	FlashWayOff          = "boolean",

--- a/Scripts/SL_Init.lua
+++ b/Scripts/SL_Init.lua
@@ -13,6 +13,7 @@ local PlayerDefaults = {
 				Mini = "0%",
 				BackgroundFilter = "Off",
 				VisualDelay = "0ms",
+				NotefieldShift = "0",
 
 				HideTargets = false,
 				HideSongBG = false,

--- a/metrics.ini
+++ b/metrics.ini
@@ -650,7 +650,7 @@ RowPositionTransformFunction=function(self,positionIndex,itemIndex,numItems) sel
 RepeatRate=30
 AllowRepeatingChangeValueInput=true
 LineNames=(function() \
-	local lines = "SpeedModType,SpeedMod,Mini,Perspective,NoteSkinSL,Judgment,ComboFont,HoldJudgment,BackgroundFilter,VisualDelay,MusicRate,Stepchart,ScreenAfterPlayerOptions" \
+	local lines = "SpeedModType,SpeedMod,Mini,Perspective,NoteSkinSL,Judgment,ComboFont,HoldJudgment,BackgroundFilter,VisualDelay,NotefieldShift,MusicRate,Stepchart,ScreenAfterPlayerOptions" \
 	if GAMESTATE:GetCurrentGame():GetName() == "pump" then lines = lines:gsub("HoldJudgment,","") end \
 	return lines \
 end)()
@@ -665,6 +665,7 @@ LineJudgment="lua,CustomOptionRow('JudgmentGraphic')"
 LineComboFont="lua,CustomOptionRow('ComboFont')"
 LineBackgroundFilter="lua,CustomOptionRow('BackgroundFilter')"
 LineVisualDelay="lua,CustomOptionRow('VisualDelay')"
+LineNotefieldShift="lua,CustomOptionRow('NotefieldShift')"
 LineMusicRate="lua,CustomOptionRow('MusicRate')"
 LineStepchart="lua,CustomOptionRow('Stepchart')"
 LineScreenAfterPlayerOptions="lua,CustomOptionRow('ScreenAfterPlayerOptions')"


### PR DESCRIPTION
Adds the option to shift the entire notefield up or down. This doesn't affect any other elements on the notefield other than the column cue countdown number. Also implemented option to toggle column countdown on or off.