### PR TITLE
Add option to indicate held misses in judgment

### DIFF
--- a/Graphics/Player judgment.lua
+++ b/Graphics/Player judgment.lua
@@ -35,6 +35,13 @@ end
 
 local maxTimingOffset = GetTimingWindow(enabledTimingWindows[#enabledTimingWindows])
 
+local font = mods.ComboFont
+if font == "Wendy" or font == "Wendy (Cursed)" then
+	font = "Wendy/_wendy small"
+else
+	font = "_Combo Fonts/" .. font .. "/"
+end
+
 return Def.ActorFrame{
 	Name="Player Judgment",
 	InitCommand=function(self)
@@ -125,5 +132,40 @@ return Def.ActorFrame{
 			end
 		end,
 		ResetCommand=function(self) self:finishtweening():stopeffect():visible(false) end
-	}
+	},
+	
+	LoadFont(font)..{
+        Text = "",
+        InitCommand = function(self)
+            self:zoom(1):shadowlength(1):y(-35)
+        end,
+        JudgmentMessageCommand = function(self, params)
+            if params.Player ~= player then return end
+            if params.HoldNoteScore then return end
+			if not mods.ShowHeldMiss then return end
+
+			local isHeld = false
+			for col,tapnote in pairs(params.Notes) do
+				local tnt = ToEnumShortString(tapnote:GetTapNoteType())
+				if tnt == "Tap" or tnt == "HoldHead" or tnt == "Lift" then
+					local tns = ToEnumShortString(params.TapNoteScore)
+					if tnt ~= "Lift" and tns == "Miss" and tapnote:GetTapNoteResult():GetHeld() then
+						isHeld = true
+					end
+				end
+			end
+			
+			if isHeld then
+				self:finishtweening()
+				self:diffusealpha(1)
+					:settext("HELD")
+					:diffuse(color("#ff0000"))
+					:sleep(0.5)
+					:diffusealpha(0)
+			else
+				self:finishtweening()
+				self:diffusealpha(0)
+			end
+        end
+    },
 }

--- a/Languages/en.ini
+++ b/Languages/en.ini
@@ -1059,6 +1059,7 @@ NPSGraphAtTop=Density Graph at Top
 JudgmentTilt=Judgment Tilt
 ColumnCues=Column Cues
 ColumnCountdown=Column Countdown
+ShowHeldMiss=Show Held Miss Judgments
 DisplayScorebox=Display Scorebox
 
 # ErrorBar

--- a/Scripts/SL-PlayerOptions.lua
+++ b/Scripts/SL-PlayerOptions.lua
@@ -555,13 +555,13 @@ local Overrides = {
 		Values = function()
 			local vals = {}
 			if IsUsingWideScreen() then
-				vals = { "JudgmentTilt", "ColumnCues", "ColumnCountdown" }
+				vals = { "JudgmentTilt", "ColumnCues", "ColumnCountdown", "ShowHeldMiss" }
 				if IsServiceAllowed(SL.GrooveStats.GetScores) then
 					vals[#vals+1] = "DisplayScorebox"
 				end
 			else
 				-- Add in the two removed options if not in WideScreen.
-				vals = { "MissBecauseHeld", "NPSGraphAtTop", "JudgmentTilt", "ColumnCues", "ColumnCountdown" }
+				vals = { "MissBecauseHeld", "NPSGraphAtTop", "JudgmentTilt", "ColumnCues", "ColumnCountdown", "ShowHeldMiss" }
 			end
 			return vals
 		end
@@ -651,7 +651,7 @@ local Overrides = {
 			local first = -100
 			local last = 100
 			local step = 1
-			return stringify( range(first, last, step), "%g")
+			return range(first, last, step)
 		end,
 		ExportOnChange = true,
 		LayoutType = "ShowOneInRow",

--- a/Scripts/SL-PlayerProfiles.lua
+++ b/Scripts/SL-PlayerProfiles.lua
@@ -62,6 +62,7 @@ local permitted_profile_settings = {
 	JudgmentTilt         = "boolean",
 	ColumnCues           = "boolean",
 	ColumnCountdown      = "boolean",
+	ShowHeldMiss         = "boolean",
 	DisplayScorebox      = "boolean",
 
 	ErrorBar             = "string",
@@ -75,7 +76,7 @@ local permitted_profile_settings = {
 	SmallerWhite     = "boolean",
 
 	VisualDelay          = "string",
-	NotefieldShift       = "string",
+	NotefieldShift       = "number",
 	
 	FlashMiss            = "boolean",
 	FlashWayOff          = "boolean",

--- a/Scripts/SL_Init.lua
+++ b/Scripts/SL_Init.lua
@@ -13,7 +13,7 @@ local PlayerDefaults = {
 				Mini = "0%",
 				BackgroundFilter = "Off",
 				VisualDelay = "0ms",
-				NotefieldShift = "0",
+				NotefieldShift = 0,
 
 				HideTargets = false,
 				HideSongBG = false,
@@ -38,6 +38,8 @@ local PlayerDefaults = {
 				NPSGraphAtTop = false,
 				JudgmentTilt = false,
 				ColumnCues = false,
+				ColumnCountdown = false,
+				ShowHeldMiss = false,
 				DisplayScorebox = true,
 
 				ErrorBar = "None",


### PR DESCRIPTION
Adds "Show Held Miss Judgments" to "Gameplay Extras" row. When enabled, displays "HELD" above "Miss" judgment during gameplay if the miss was held.