### PR TITLE
FA+ Marquee for 10ms

### DIFF
--- a/BGAnimations/ScreenEvaluation common/Panes/Pane2/JudgmentLabels.lua
+++ b/BGAnimations/ScreenEvaluation common/Panes/Pane2/JudgmentLabels.lua
@@ -89,6 +89,37 @@ for i=1, #TapNoteScores.Types do
 				self:diffuse( TapNoteScores.Colors[i] )
 			end
 		}
+		if i==1 and SL[pn].ActiveModifiers.SmallerWhite then
+			local show15 = false
+			t[#t+1] = LoadFont("Common Normal")..{
+				Text="10ms",
+				InitCommand=function(self) self:zoom(0.6):horizalign(right):maxwidth(76) end,
+				BeginCommand=function(self)
+					self:x( (controller == PLAYER_1 and 28) or -28 )
+					if maxCount > 9999 then
+						length = math.floor(math.log10(maxCount)+1)
+						finalPos = 28 - 11*(length-4)
+						finalZoom = 0.6 - 0.1*(length-4)
+						self:x( (controller == PLAYER_1 and finalPos) or -finalPos ):zoom(finalZoom)
+					end
+					self:y(i*26-36)
+					-- diffuse the JudgmentLabels the appropriate colors for the current GameMode
+					self:diffuse( TapNoteScores.Colors[i] )
+					self:playcommand("Marquee")
+				end,
+				MarqueeCommand=function(self)
+					if show15 then
+						self:settext("15ms")
+						show15 = false
+					else
+						self:settext("10ms")
+						show15 = true
+					end
+					
+					self:sleep(2):queuecommand("Marquee")
+				end
+			}
+		end
 	end
 end
 

--- a/BGAnimations/ScreenEvaluation common/Panes/Pane2/JudgmentNumbers.lua
+++ b/BGAnimations/ScreenEvaluation common/Panes/Pane2/JudgmentNumbers.lua
@@ -47,6 +47,14 @@ end
 for i=1,#TapNoteScores.Types do
 	local window = TapNoteScores.Types[i]
 	local number = counts[window] or 0
+	local number15 = number
+	local display15 = false
+	
+	if i == 1 then
+		number15 = counts["W015"]
+	elseif i == 2 then
+		number15 = counts["W115"]
+	end
 
 	-- actual numbers
 	t[#t+1] = Def.RollingNumbers{
@@ -73,6 +81,19 @@ for i=1,#TapNoteScores.Types do
 			self:x( TapNoteScores.x[ToEnumShortString(controller)] )
 			self:y((i-1)*32 -24)
 			self:targetnumber(number)
+			if SL[pn].ActiveModifiers.SmallerWhite then
+				self:playcommand("Marquee")
+			end
+		end,
+		MarqueeCommand=function(self)
+			if display15 then
+				self:settext(("%04.0f"):format(number15))
+				display15 = false
+			else
+				self:settext(("%04.0f"):format(number))
+				display15 = true
+			end
+			self:sleep(2):queuecommand("Marquee")
 		end
 	}
 


### PR DESCRIPTION
Marquee between 10ms and 15ms blue Fantastic window judge counts if 10ms mode was turned on.