### PR TITLE
Expanded results screen scatterplots

### DIFF
--- a/BGAnimations/ScreenEvaluation common/InputHandler.lua
+++ b/BGAnimations/ScreenEvaluation common/InputHandler.lua
@@ -9,7 +9,7 @@ end
 -- -----------------------------------------------------------------------
 -- local variables
 
-local panes, active_pane = {}, {}
+local panes, active_pane, active_graph = {}, {}, {}
 
 local style = ToEnumShortString(GAMESTATE:GetCurrentStyle():GetStyleType())
 local players = GAMESTATE:GetHumanPlayers()
@@ -31,6 +31,7 @@ local secondary_i = clamp(SL[ToEnumShortString(mpn)].EvalPaneSecondary, 1, num_p
 for controller=1,2 do
 
 	panes[controller] = {}
+	active_graph[controller] = 1
 
 	-- Iterate through all potential panes, and only add the non-nil ones to the
 	-- list of panes we want to consider.
@@ -130,6 +131,31 @@ return function(event)
 
 	if event.type == "InputEventType_FirstPress" and panes[cn] then
 
+		if event.GameButton == "MenuUp" or event.GameButton == "MenuDown" then
+			if event.GameButton == "MenuUp" then
+				active_graph[cn] = (active_graph[cn] - 1) % 3
+				if active_graph[cn] == 0 then active_graph[cn] = 3 end
+			else
+				active_graph[cn] = (active_graph[cn] % 3) + 1
+			end
+			
+			if #players==1 then
+				af:GetChild(ToEnumShortString(mpn) .. "_AF_Lower"):GetChild("JudgeGraph"):visible(active_graph[cn] == 1)
+				af:GetChild(ToEnumShortString(mpn) .. "_AF_Lower"):GetChild("ArrowGraph"):visible(active_graph[cn] > 1)
+				af:GetChild(ToEnumShortString(mpn) .. "_AF_Lower"):GetChild("ArrowGraph"):GetChild("ArrowPlot"):visible(active_graph[cn] == 2)
+				af:GetChild(ToEnumShortString(mpn) .. "_AF_Lower"):GetChild("ArrowGraph"):GetChild("FootPlot"):visible(active_graph[cn] == 3)
+				af:GetChild(ToEnumShortString(mpn) .. "_AF_Lower"):GetChild("ArrowGraph"):GetChild("Feet"):visible(active_graph[cn] == 3)
+				panes[ocn][3]:playcommand("Graph", {graph=active_graph[cn]})
+			else
+				af:GetChild("P" .. cn .. "_AF_Lower"):GetChild("JudgeGraph"):visible(active_graph[cn] == 1)
+				af:GetChild("P" .. cn .. "_AF_Lower"):GetChild("ArrowGraph"):visible(active_graph[cn] > 1)
+				af:GetChild("P" .. cn .. "_AF_Lower"):GetChild("ArrowGraph"):GetChild("ArrowPlot"):visible(active_graph[cn] == 2)
+				af:GetChild("P" .. cn .. "_AF_Lower"):GetChild("ArrowGraph"):GetChild("FootPlot"):visible(active_graph[cn] == 3)
+				af:GetChild("P" .. cn .. "_AF_Lower"):GetChild("ArrowGraph"):GetChild("Feet"):visible(active_graph[cn] == 3)
+			end
+			panes[cn][3]:playcommand("Graph", {graph=active_graph[cn]})
+		end
+		
 		if event.GameButton == "MenuRight" or event.GameButton == "MenuLeft" then
 			if event.GameButton == "MenuRight" then
 				active_pane[cn] = (active_pane[cn] % #panes[cn]) + 1

--- a/BGAnimations/ScreenEvaluation common/Panes/Pane3/Arrows.lua
+++ b/BGAnimations/ScreenEvaluation common/Panes/Pane3/Arrows.lua
@@ -2,6 +2,7 @@ local player = ...
 local pn = ToEnumShortString(player)
 local track_missbcheld = SL[pn].ActiveModifiers.MissBecauseHeld
 local track_earlyjudgments = SL[pn].ActiveModifiers.TrackEarlyJudgments
+local ArrowColors = { Color.Red, Color.Blue, Color.Green, Color.Yellow }
 
 -- a string representing the NoteSkin the player was using
 local noteskin = GAMESTATE:GetPlayerState(player):GetCurrentPlayerOptions():NoteSkin()
@@ -15,6 +16,7 @@ local game  = GAMESTATE:GetCurrentGame():GetName()
 local style = GAMESTATE:GetCurrentStyle()
 local style_name = style:GetName()
 local num_columns = style:ColumnsPerPlayer()
+local activeGraph = 1
 
 local rows = { "W1", "W2", "W3", "W4", "W5", "Miss" }
 if SL[pn].ActiveModifiers.ShowFaPlusWindow then
@@ -46,6 +48,10 @@ local row_height = box_height/#rows
 
 local af = Def.ActorFrame{}
 af.InitCommand=function(self) self:xy(-104, _screen.cy-40) end
+af.GraphCommand=function(self, params)
+	activeGraph = params.graph
+	self:playcommand("Update")
+end
 
 
 for i, column in ipairs( cols ) do
@@ -65,6 +71,13 @@ for i, column in ipairs( cols ) do
 	af[#af+1] = LoadActor(THEME:GetPathB("","_modules/NoteSkinPreview.lua"), {noteskin_name=noteskin, column=column.Name})..{
 		OnCommand=function(self)
 			self:x( _x ):zoom(0.4):visible(true)
+		end,
+		UpdateCommand=function(self)
+			if activeGraph ~= 2 then
+				self:stoptweening():stopeffect()
+			else
+				self:glowshift():effectcolor1(ArrowColors[i]):effectcolor2(ArrowColors[i])
+			end
 		end
 	}
 

--- a/BGAnimations/ScreenEvaluation common/PerPlayer/Lower/ScatterPlotDirection.lua
+++ b/BGAnimations/ScreenEvaluation common/PerPlayer/Lower/ScatterPlotDirection.lua
@@ -1,0 +1,126 @@
+-- if we're in CourseMode, bail now
+-- the normal LifeMeter graph (Def.GraphDisplay) will be drawn
+if GAMESTATE:IsCourseMode() then return end
+
+-- arguments passed in from Graphs.lua
+local args = ...
+local player = args.player
+local GraphWidth = args.GraphWidth
+local GraphHeight = args.GraphHeight
+local ArrowColors = { Color.Red, Color.Blue, Color.Green, Color.Yellow }
+
+local pn = ToEnumShortString(player)
+
+-- sequential_offsets gathered in ./BGAnimations/ScreenGameplay overlay/JudgmentOffsetTracking.lua
+local sequential_offsets = SL[pn].Stages.Stats[SL.Global.Stages.PlayedThisGame + 1].sequential_offsets
+local death_second = SL[pn].Stages.Stats[SL.Global.Stages.PlayedThisGame + 1].DeathSecond
+
+-- a table to store the AMV's vertices
+local verts= {}
+local Steps = GAMESTATE:GetCurrentSteps(player)
+local TimingData = Steps:GetTimingData()
+-- FirstSecond and LastSecond are used in scaling the x-coordinates of the AMV's vertices
+local FirstSecond = math.min(TimingData:GetElapsedTimeFromBeat(0), 0)
+local LastSecond = GAMESTATE:GetCurrentSong():GetLastSecond()
+
+-- variables that will be used and re-used in the loop while calculating the AMV's vertices
+local Offset, CurrentSecond, TimingWindow, x, y, c, r, g, b
+
+-- ---------------------------------------------
+-- if players have disabled W4 or W4+W5, there will be a smaller pool
+-- of judgments that could have possibly been earned
+local worst_window = GetTimingWindow(SL[pn].Stages.Stats[SL.Global.Stages.PlayedThisGame + 1].worst_window)
+-- local windows = SL[pn].ActiveModifiers.TimingWindows
+-- for i=NumJudgmentsAvailable(),1,-1 do
+-- 	if windows[i] then
+--		worst_window = GetTimingWindow(i)
+--		break
+--	end
+-- end
+
+-- ---------------------------------------------
+
+local colors = {}
+for w=NumJudgmentsAvailable(),1,-1 do
+	if SL[pn].ActiveModifiers.TimingWindows[w]==true then
+		colors[w] = DeepCopy(SL.JudgmentColors[SL.Global.GameMode][w])
+	else
+		colors[w] = DeepCopy(colors[w+1] or SL.JudgmentColors[SL.Global.GameMode][w+1])
+	end
+end
+
+-- ---------------------------------------------
+
+for t in ivalues(sequential_offsets) do
+	CurrentSecond = t[1]
+	Offset = t[2]
+	Direction = t[3]
+
+	if Offset ~= "Miss" then
+		CurrentSecond = CurrentSecond - Offset
+	else
+		CurrentSecond = CurrentSecond - worst_window
+	end
+
+	-- pad the right end because the time measured seems to lag a little...
+	x = scale(CurrentSecond, FirstSecond, LastSecond + 0.05, 0, GraphWidth)
+	
+	-- get the appropriate color from the global SL table
+	if Direction > 0 and Direction < 5 then
+		c = ArrowColors[Direction]
+	else
+		c = Color.White
+	end
+
+	-- get the red, green, and blue values from that color
+	r = c[1]
+	g = c[2]
+	b = c[3]
+
+	if Offset ~= "Miss" then
+		-- DetermineTimingWindow() is defined in ./Scripts/SL-Helpers.lua
+		TimingWindow = DetermineTimingWindow(Offset)
+		y = scale(Offset, worst_window, -worst_window, 0, GraphHeight)
+
+		-- insert four datapoints into the verts tables, effectively generating a single quadrilateral
+		-- top left,  top right,  bottom right,  bottom left
+		if death_second ~= nil and CurrentSecond > death_second then
+			table.insert( verts, {{x,y,0}, {r,g,b,0.333}} )
+			table.insert( verts, {{x+1.5,y,0}, {r,g,b,0.333}} )
+			table.insert( verts, {{x+1.5,y+1.5,0}, {r,g,b,0.333}} )
+			table.insert( verts, {{x,y+1.5,0}, {r,g,b,0.333}} )
+		else
+			table.insert( verts, {{x,y,0}, {r,g,b,0.666}} )
+			table.insert( verts, {{x+1.5,y,0}, {r,g,b,0.666}} )
+			table.insert( verts, {{x+1.5,y+1.5,0}, {r,g,b,0.666}} )
+			table.insert( verts, {{x,y+1.5,0}, {r,g,b,0.666}} )
+		end
+	else
+		-- else, a miss should be a quadrilateral that is the height of the entire graph and red
+		if death_second ~= nil and CurrentSecond > death_second then
+			table.insert( verts, {{x, 0, 0}, {r,g,b,0.111}} )
+			table.insert( verts, {{x+1, 0, 0}, {r,g,b,0.111}} )
+			table.insert( verts, {{x+1, GraphHeight, 0}, {r,g,b,0.111}} )
+			table.insert( verts, {{x, GraphHeight, 0}, {r,g,b,0.111}} )
+		else
+			table.insert( verts, {{x, 0, 0}, {r,g,b,0.333}} )
+			table.insert( verts, {{x+1, 0, 0}, {r,g,b,0.333}} )
+			table.insert( verts, {{x+1, GraphHeight, 0}, {r,g,b,0.333}} )
+			table.insert( verts, {{x, GraphHeight, 0}, {r,g,b,0.333}} )
+		end
+	end
+end
+
+-- the scatter plot will use an ActorMultiVertex in "Quads" mode
+-- this is more efficient than drawing n Def.Quads (one for each judgment)
+-- because the entire AMV will be a single Actor rather than n Actors with n unique Draw() calls.
+local amv = Def.ActorMultiVertex{
+	Name="ArrowPlot",
+	InitCommand=function(self) self:x(-GraphWidth/2) end,
+	OnCommand=function(self)
+		self:SetDrawState({Mode="DrawMode_Quads"})
+			:SetVertices(verts)
+	end,
+}
+
+return amv

--- a/BGAnimations/ScreenEvaluation common/PerPlayer/Lower/ScatterPlotFoot.lua
+++ b/BGAnimations/ScreenEvaluation common/PerPlayer/Lower/ScatterPlotFoot.lua
@@ -1,0 +1,127 @@
+-- if we're in CourseMode, bail now
+-- the normal LifeMeter graph (Def.GraphDisplay) will be drawn
+if GAMESTATE:IsCourseMode() then return end
+
+-- arguments passed in from Graphs.lua
+local args = ...
+local player = args.player
+local GraphWidth = args.GraphWidth
+local GraphHeight = args.GraphHeight
+local FootColors = { Color.Red, Color.Blue }
+
+local pn = ToEnumShortString(player)
+
+-- sequential_offsets gathered in ./BGAnimations/ScreenGameplay overlay/JudgmentOffsetTracking.lua
+local sequential_offsets = SL[pn].Stages.Stats[SL.Global.Stages.PlayedThisGame + 1].sequential_offsets
+local death_second = SL[pn].Stages.Stats[SL.Global.Stages.PlayedThisGame + 1].DeathSecond
+
+-- a table to store the AMV's vertices
+local verts= {}
+local Steps = GAMESTATE:GetCurrentSteps(player)
+local TimingData = Steps:GetTimingData()
+-- FirstSecond and LastSecond are used in scaling the x-coordinates of the AMV's vertices
+local FirstSecond = math.min(TimingData:GetElapsedTimeFromBeat(0), 0)
+local LastSecond = GAMESTATE:GetCurrentSong():GetLastSecond()
+
+-- variables that will be used and re-used in the loop while calculating the AMV's vertices
+local Offset, CurrentSecond, TimingWindow, x, y, c, r, g, b
+
+-- ---------------------------------------------
+-- if players have disabled W4 or W4+W5, there will be a smaller pool
+-- of judgments that could have possibly been earned
+local worst_window = GetTimingWindow(SL[pn].Stages.Stats[SL.Global.Stages.PlayedThisGame + 1].worst_window)
+-- local windows = SL[pn].ActiveModifiers.TimingWindows
+-- for i=NumJudgmentsAvailable(),1,-1 do
+-- 	if windows[i] then
+--		worst_window = GetTimingWindow(i)
+--		break
+--	end
+-- end
+
+-- ---------------------------------------------
+
+local colors = {}
+for w=NumJudgmentsAvailable(),1,-1 do
+	if SL[pn].ActiveModifiers.TimingWindows[w]==true then
+		colors[w] = DeepCopy(SL.JudgmentColors[SL.Global.GameMode][w])
+	else
+		colors[w] = DeepCopy(colors[w+1] or SL.JudgmentColors[SL.Global.GameMode][w+1])
+	end
+end
+
+-- ---------------------------------------------
+
+for t in ivalues(sequential_offsets) do
+	CurrentSecond = t[1]
+	Offset = t[2]
+	IsStream = t[4]
+	Foot = t[5]
+
+	if Offset ~= "Miss" then
+		CurrentSecond = CurrentSecond - Offset
+	else
+		CurrentSecond = CurrentSecond - worst_window
+	end
+
+	-- pad the right end because the time measured seems to lag a little...
+	x = scale(CurrentSecond, FirstSecond, LastSecond + 0.05, 0, GraphWidth)
+	
+	-- get the appropriate color from the global SL table
+	if IsStream then
+		c = Foot and FootColors[1] or FootColors[2]
+	else
+		c = Color.Black
+	end
+
+	-- get the red, green, and blue values from that color
+	r = c[1]
+	g = c[2]
+	b = c[3]
+
+	if Offset ~= "Miss" then
+		-- DetermineTimingWindow() is defined in ./Scripts/SL-Helpers.lua
+		TimingWindow = DetermineTimingWindow(Offset)
+		y = scale(Offset, worst_window, -worst_window, 0, GraphHeight)
+
+		-- insert four datapoints into the verts tables, effectively generating a single quadrilateral
+		-- top left,  top right,  bottom right,  bottom left
+		if death_second ~= nil and CurrentSecond > death_second then
+			table.insert( verts, {{x,y,0}, {r,g,b,0.333}} )
+			table.insert( verts, {{x+1.5,y,0}, {r,g,b,0.333}} )
+			table.insert( verts, {{x+1.5,y+1.5,0}, {r,g,b,0.333}} )
+			table.insert( verts, {{x,y+1.5,0}, {r,g,b,0.333}} )
+		else
+			table.insert( verts, {{x,y,0}, {r,g,b,0.666}} )
+			table.insert( verts, {{x+1.5,y,0}, {r,g,b,0.666}} )
+			table.insert( verts, {{x+1.5,y+1.5,0}, {r,g,b,0.666}} )
+			table.insert( verts, {{x,y+1.5,0}, {r,g,b,0.666}} )
+		end
+	else
+		-- else, a miss should be a quadrilateral that is the height of the entire graph and red
+		if death_second ~= nil and CurrentSecond > death_second then
+			table.insert( verts, {{x, 0, 0}, {r,g,b,0.111}} )
+			table.insert( verts, {{x+1, 0, 0}, {r,g,b,0.111}} )
+			table.insert( verts, {{x+1, GraphHeight, 0}, {r,g,b,0.111}} )
+			table.insert( verts, {{x, GraphHeight, 0}, {r,g,b,0.111}} )
+		else
+			table.insert( verts, {{x, 0, 0}, {r,g,b,0.333}} )
+			table.insert( verts, {{x+1, 0, 0}, {r,g,b,0.333}} )
+			table.insert( verts, {{x+1, GraphHeight, 0}, {r,g,b,0.333}} )
+			table.insert( verts, {{x, GraphHeight, 0}, {r,g,b,0.333}} )
+		end
+	end
+end
+
+-- the scatter plot will use an ActorMultiVertex in "Quads" mode
+-- this is more efficient than drawing n Def.Quads (one for each judgment)
+-- because the entire AMV will be a single Actor rather than n Actors with n unique Draw() calls.
+local amv = Def.ActorMultiVertex{
+	Name="FootPlot",
+	InitCommand=function(self) self:x(-GraphWidth/2) end,
+	OnCommand=function(self)
+		self:SetDrawState({Mode="DrawMode_Quads"})
+			:SetVertices(verts)
+	end,
+}
+
+return amv

--- a/BGAnimations/ScreenEvaluation common/PerPlayer/Lower/default.lua
+++ b/BGAnimations/ScreenEvaluation common/PerPlayer/Lower/default.lua
@@ -49,6 +49,7 @@ af[#af+1] = Def.Quad{
 
 -- "Look at this graph."  –Some sort of meme on The Internet
 af[#af+1] = LoadActor("./Graphs.lua", player)
+af[#af+1] = LoadActor("./Graphs-bg.lua", player)
 
 -- list of modifiers used by this player for this song
 af[#af+1] = LoadActor("./PlayerModifiers.lua", player)


### PR DESCRIPTION
Scatterplot now supports per-arrow breakdown and per-foot (during streams only) breakdown. Use MenuUp and MenuDown to cycle through the different scatterplot modes.