### PR TITLE
Add settings for GS integration on song select

### DIFF
--- a/BGAnimations/ScreenSelectMusic overlay/PaneDisplay.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/PaneDisplay.lua
@@ -325,6 +325,21 @@ af[#af+1] = RequestResponseActor(17, 50)..{
 		local query = {}
 		local requestCacheKey = ""
 
+		if ThemePrefs.Get("MusicWheelGS") == "Pane" then
+			for i=1,2 do
+				local pn = "P"..i
+				if SL[pn].ApiKey ~= "" and SL[pn].Streams.Hash ~= "" then
+					query["chartHashP"..i] = SL[pn].Streams.Hash
+					headers["x-api-key-player-"..i] = SL[pn].ApiKey
+					requestCacheKey = requestCacheKey .. SL[pn].Streams.Hash .. SL[pn].ApiKey .. pn
+					local loadingText = master:GetChild("PaneDisplayP"..i):GetChild("Loading")
+					loadingText:visible(true)
+					loadingText:settext("Loading ..."):diffuse(Color.Black)
+					sendRequest = true
+				end
+			end
+		end
+
 		-- Only send the request if it's applicable.
 		if sendRequest then
 			requestCacheKey = CRYPTMAN:SHA256String(requestCacheKey.."-player-scores")
@@ -477,7 +492,13 @@ for player in ivalues(PlayerNumber) do
 			self:y(pos.row[1])
 		end,
 		SetCommand=function(self)
-			self:queuecommand("SetDefault")
+			-- We overload this actor to work both for GrooveStats and also offline.
+			-- If we're connected, we let the ResponseProcessor set the text
+			if IsServiceAllowed(SL.GrooveStats.GetScores) and ThemePrefs.Get("MusicWheelGS") == "Pane" then
+				self:settext("----"):diffuse(Color.Black)
+			else
+				self:queuecommand("SetDefault")
+			end
 		end,
 		SetDefaultCommand=function(self)
 			local SongOrCourse, StepsOrTrail = GetSongAndSteps(player)
@@ -496,7 +517,13 @@ for player in ivalues(PlayerNumber) do
 			self:y(pos.row[1])
 		end,
 		SetCommand=function(self)
-			self:queuecommand("SetDefault")
+			-- We overload this actor to work both for GrooveStats and also offline.
+			-- If we're connected, we let the ResponseProcessor set the text
+			if IsServiceAllowed(SL.GrooveStats.GetScores) and ThemePrefs.Get("MusicWheelGS") == "Pane" then
+				self:settext("??.??%"):diffuse(Color.Black)
+			else
+				self:queuecommand("SetDefault")
+			end
 		end,
 		SetDefaultCommand=function(self)
 			local SongOrCourse, StepsOrTrail = GetSongAndSteps(player)
@@ -518,7 +545,13 @@ for player in ivalues(PlayerNumber) do
 			self:y(pos.row[2])
 		end,
 		SetCommand=function(self)
-			self:queuecommand("SetDefault")
+			-- We overload this actor to work both for GrooveStats and also offline.
+			-- If we're connected, we let the ResponseProcessor set the text
+			if IsServiceAllowed(SL.GrooveStats.GetScores) and ThemePrefs.Get("MusicWheelGS") == "Pane" then
+				self:settext("----")
+			else
+				self:queuecommand("SetDefault")
+			end
 		end,
 		SetDefaultCommand=function(self)
 			local playerScore = GetScoreForPlayer(player)
@@ -536,7 +569,13 @@ for player in ivalues(PlayerNumber) do
 			self:y(pos.row[2])
 		end,
 		SetCommand=function(self)
-			self:queuecommand("SetDefault")
+			-- We overload this actor to work both for GrooveStats and also offline.
+			-- If we're connected, we let the ResponseProcessor set the text
+			if IsServiceAllowed(SL.GrooveStats.GetScores) and ThemePrefs.Get("MusicWheelGS") == "Pane" then
+				self:settext("??.??%")
+			else
+				self:queuecommand("SetDefault")
+			end
 		end,
 		SetDefaultCommand=function(self)
 			local playerScore = GetScoreForPlayer(player)
@@ -635,6 +674,44 @@ for player in ivalues(PlayerNumber) do
 			self:settext( meter )
 		end
 	}
+
+	-- Add actors for Rival score data. Hidden by default
+	-- We position relative to column 3 for spacing reasons.
+	if ThemePrefs.Get("MusicWheelGS") == "Pane" then
+		for i=1,3 do
+			-- Rival Machine Tag
+			af2[#af2+1] = LoadFont("Common Normal")..{
+				Name="Rival"..i.."Name",
+				InitCommand=function(self)
+					self:zoom(text_zoom):diffuse(Color.Black):maxwidth(30)
+					self:x(pos.col[3]+50*text_zoom)
+					self:y(pos.row[i])
+				end,
+				OnCommand=function(self)
+					self:visible(IsServiceAllowed(SL.GrooveStats.GetScores))
+				end,
+				SetCommand=function(self)
+					self:settext("----"):diffuse(Color.Black)
+				end
+			}
+	
+			-- Rival HighScore
+			af2[#af2+1] = LoadFont("Common Normal")..{
+				Name="Rival"..i.."Score",
+				InitCommand=function(self)
+					self:zoom(text_zoom):diffuse(Color.Black):horizalign(right)
+					self:x(pos.col[3]+125*text_zoom)
+					self:y(pos.row[i])
+				end,
+				OnCommand=function(self)
+					self:visible(IsServiceAllowed(SL.GrooveStats.GetScores))
+				end,
+				SetCommand=function(self)
+					self:settext("??.??%"):diffuse(Color.Black)
+				end
+			}
+		end
+	end
 end
 
 return af

--- a/BGAnimations/ScreenSelectMusic overlay/PerPlayer/Scorebox.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/PerPlayer/Scorebox.lua
@@ -1,6 +1,9 @@
 -- No need to get GS scores for courses
 if GAMESTATE:IsCourseMode() then return end
 
+-- Don't display if Music Wheel GS integration isn't set to Scorebox.
+if ThemePrefs.Get("MusicWheelGS") ~= "Scorebox" then return end
+
 local player = ...
 local pn = ToEnumShortString(player)
 

--- a/Languages/en.ini
+++ b/Languages/en.ini
@@ -609,6 +609,7 @@ AllowScreenEvalSummary=Allow Screen\nEval Summary
 AllowScreenNameEntry=Allow Screen\nName Entry
 AllowScreenGameOver=Allow Screen\nGame Over
 MusicWheelStyle=MusicWheel Style
+MusicWheelGS=MusicWheel GS Display
 AllowDanceSolo=Allow Dance Solo
 HideStockNoteSkins=Stock NoteSkins
 ShowGradesInMusicWheel=Show Grades\nIn MusicWheel
@@ -805,6 +806,7 @@ DefaultGameMode=Set the starting position of the cursor when selecting a GameMod
 AllowFailingOutOfSet=If 'Yes' players can potentially fail out of a set early.  If 'No' players will always be able to play all their songs.\n\nThis has no impact in Event Mode.
 NumberOfContinuesAllowed=Allow players to chain multiple games together by entering extra credits. Set this to 0 if you want to disable it.\n\nThis feature only applies to Pay Mode, because credits only exist in Pay Mode.
 MusicWheelSpeed=Change the speed at which the MusicWheel will scroll through content.\n\nA faster MusicWheel is especially helpful when the MenuTimer is enabled.
+MusicWheelGS=Select how to display scores retrieved from GrooveStats.
 
 AllowScreenSelectProfile=Set this to 'No' if you want to skip the Select Profile screen.\n\nThe Select Profile screen can be helpful if you have multiple local profiles.
 AllowScreenSelectColor=Set this to 'No' if you want to skip the Select Color screen.\n\nNote that Rainbow Mode disables the Select Color screen by default.

--- a/Scripts/99 SL-ThemePrefs.lua
+++ b/Scripts/99 SL-ThemePrefs.lua
@@ -61,6 +61,11 @@ SL_CustomPrefs.Get = function()
 			Default = "ITG",
 			Choices = { "ITG", "IIDX" }
 		},
+		MusicWheelGS =
+		{
+			Default = "Pane",
+			Choices = { "Scorebox", "Pane", "Off" }
+		},
 		AllowDanceSolo =
 		{
 			Default = false,

--- a/metrics.ini
+++ b/metrics.ini
@@ -1143,7 +1143,7 @@ OptionRowNormalMetricsGroup="OptionRowSimplyLoveOptions"
 LineNames=(function() \
 	local lines = "VisualStyle" \
 	if ThemePrefs.Get("VisualStyle") ~= "SRPG6" then lines = lines .. ",RainbowMode" end \
-	lines = lines.. ",,MusicWheelSpeed,,MusicWheelStyle,AutoStyle,DefaultGameMode,AllowFailingOutOfSet,NumberOfContinuesAllowed,CasualMaxMeter,SelectProfile,SelectColor,EvalSummary,NameEntry,GameOver,HideStockNoteSksins,DanceSolo,Nice,WriteCustomScores,KeyboardFeatures" \
+	lines = lines.. ",,MusicWheelSpeed,,MusicWheelStyle,MusicWheelGS,AutoStyle,DefaultGameMode,AllowFailingOutOfSet,NumberOfContinuesAllowed,CasualMaxMeter,SelectProfile,SelectColor,EvalSummary,NameEntry,GameOver,HideStockNoteSksins,DanceSolo,Nice,WriteCustomScores,KeyboardFeatures" \
 	if Sprite.LoadFromCached ~= nil then lines = lines .. ",UseImageCache" end \
 	return lines \
 end)()
@@ -1156,6 +1156,7 @@ LineAllowFailingOutOfSet="lua,ThemePrefsRows.GetRow('AllowFailingOutOfSet')"
 LineNumberOfContinuesAllowed="lua,ThemePrefsRows.GetRow('NumberOfContinuesAllowed')"
 LineMusicWheelStyle="lua,ThemePrefsRows.GetRow('MusicWheelStyle')"
 LineMusicWheelSpeed="lua,OperatorMenuOptionRows.MusicWheelSpeed()"
+LineMusicWheelGS="lua,ThemePrefsRows.GetRow('MusicWheelGS')"
 
 LineSelectProfile="lua,ThemePrefsRows.GetRow('AllowScreenSelectProfile')"
 LineSelectColor="lua,ThemePrefsRows.GetRow('AllowScreenSelectColor')"


### PR DESCRIPTION
By request, you can now select how GS scores are displayed on the song select music wheel. This can be found in Operator Menu -> Simply Love Options -> MusicWheel GS Display

- Scorebox: Displays a 5-row scorebox of the leaderboard on the bottom.
- Pane: Updates records on the bottom pane to reflect PB, WR, and rival scores.
- Off: Doesn't automatically retrieve GrooveStats scores at all.