### PR TITLE
show total possible points in song wheel

### DIFF
--- a/Graphics/MusicWheelItem Song NormalPart/default.lua
+++ b/Graphics/MusicWheelItem Song NormalPart/default.lua
@@ -76,7 +76,7 @@ for player in ivalues(PlayerNumber) do
 						if SL[pn].ITLData["hashMap"][hash] ~= nil then
 							self:settext(tostring(("%.2f"):format(SL[pn].ITLData["hashMap"][hash]["ex"] / 100)))
 							 if (GAMESTATE:GetNumSidesJoined() == 1 and PROFILEMAN:IsPersistentProfile(player)) then 
-							 	self:settext(SL[pn].ITLData["hashMap"][hash]["points"])
+							 	self:settext(SL[pn].ITLData["hashMap"][hash]["points"] .. "/" .. tostring(SL[pn].ITLData["hashMap"][hash]["maxPoints"]))
 							 end
 							self:visible(true)
 							return


### PR DESCRIPTION
I thought this cool be a neat little addition. I won't be offended if this doesn't fit your goals with the theme :)

Normal view:
<img width="809" alt="Screenshot 2023-03-31 at 12 36 12 PM" src="https://user-images.githubusercontent.com/14972752/229213211-75b87e3e-72c9-402d-a492-ea7c54e9dcf4.png">

Long song title (notice existing clipping with percentage):
<img width="940" alt="Screenshot 2023-03-31 at 12 36 19 PM" src="https://user-images.githubusercontent.com/14972752/229213256-730cfe29-9146-4614-b89e-bca97e990891.png">
