### PR TITLE
Change the default event mode escape combo to just Back key

### DIFF
--- a/metrics.ini
+++ b/metrics.ini
@@ -1607,7 +1607,7 @@ CodeSortList2=(PREFSMAN:GetPreference("OnlyDedicatedMenuButtons") or GAMESTATE:G
 CodeSortList3=GAMESTATE:GetCurrentGame():GetName() == "pump" and "DownLeft-DownRight"
 CodeSortList4=not PREFSMAN:GetPreference("OnlyDedicatedMenuButtons") and "Left-Right"
 CodeTogglePatternInfo="Select,Select"
-CodeEscapeFromEventMode=PREFSMAN:GetPreference("EventMode") and "MenuLeft,MenuLeft,MenuRight,MenuRight,MenuLeft,MenuLeft,MenuRight,MenuRight" or ""
+CodeEscapeFromEventMode=PREFSMAN:GetPreference("EventMode") and "Back" or ""
 
 # this allows us to override the normal sort select command
 ModeMenuAvailable=false


### PR DESCRIPTION
It prompts for confirmation before leaving the song wheel in event mode with Back key (usually escape) to prevent from quitting leaving the session by mistake. I'm not convinced that anyone playing on the cab would actually be aware of the default combo of LLRRLLRR for triggering event mode escape.

![image](https://github.com/zarzob/Simply-Love-SM5/assets/9034451/a37def16-2322-4a1d-b665-52c84df623fe)
