### PR TITLE
Check stepstype for grade/lamp

### DIFF
--- a/Graphics/MusicWheelItem Grades/default.lua
+++ b/Graphics/MusicWheelItem Grades/default.lua
@@ -26,12 +26,13 @@ local function GetLamp(song)
 	if not GAMESTATE:GetCurrentSteps(pn) then return nil end
 	
 	local diff = GAMESTATE:GetCurrentSteps(pn):GetDifficulty()
+	local stepstype = GAMESTATE:GetCurrentStyle():GetStepsType()
 	
 	local stepsList = song:GetAllSteps()
 	local steps = nil
 	
 	for check in ivalues(stepsList) do
-		if check:GetDifficulty() == diff then
+		if check:GetDifficulty() == diff and check:GetStepsType() == stepstype then
 			steps = check
 			break
 		end

--- a/Graphics/MusicWheelItem Song NormalPart/GetLamp.lua
+++ b/Graphics/MusicWheelItem Song NormalPart/GetLamp.lua
@@ -25,12 +25,13 @@ local function GetLamp(song)
 	if not GAMESTATE:GetCurrentSteps(pn) then return nil end
 	
 	local diff = GAMESTATE:GetCurrentSteps(pn):GetDifficulty()
+	local stepstype = GAMESTATE:GetCurrentStyle():GetStepsType()
 	
 	local stepsList = song:GetAllSteps()
 	local steps = nil
 	
 	for check in ivalues(stepsList) do
-		if check:GetDifficulty() == diff then
+		if check:GetDifficulty() == diff and check:GetStepsType() == stepstype then
 			steps = check
 			break
 		end


### PR DESCRIPTION
Or else weird things happen when mixing singles and doubles scores.

All other places that use `GetAllSteps()` do this same check.