### PR TITLE
Give Pacemaker and TargetScore actor names

### DIFF
--- a/BGAnimations/ScreenGameplay underlay/PerPlayer/TargetScore/Pacemaker.lua
+++ b/BGAnimations/ScreenGameplay underlay/PerPlayer/TargetScore/Pacemaker.lua
@@ -32,6 +32,7 @@ local GetPossibleExScore = function(counts)
 end
 
 local pacemaker = Def.BitmapText{
+	Name="Pacemaker" .. pn,
 	Font=ThemePrefs.Get("ThemeFont") .. " Bold",
 	JudgmentMessageCommand=function(self)
 		self:queuecommand("Update")

--- a/BGAnimations/ScreenGameplay underlay/PerPlayer/TargetScore/default.lua
+++ b/BGAnimations/ScreenGameplay underlay/PerPlayer/TargetScore/default.lua
@@ -38,7 +38,9 @@ local target_score, pos_data, personal_best = LoadActor("./Setup.lua", {player, 
 
 -- ---------------------------------------------------------------
 -- add actors to the ActorFrame as needed
-local af = Def.ActorFrame{}
+local af = Def.ActorFrame{
+	Name="TargetScore" .. pn
+}
 
 if WantsTargetGraph then
 	af[#af+1] = LoadActor("./Graph-Common.lua", {player, pss, isTwoPlayers, pos_data, target_score, personal_best, use_smaller_graph})


### PR DESCRIPTION
As title states. I want to recolor the pacemaker different colors depending if it is behind or ahead, however I'm not really interested in keeping my own fork and want to use module instead. I just wasn't able to fetch the actor when it was nameless, this is the least amount of change I need for it to be viable.

